### PR TITLE
fix/curl 8.4.0

### DIFF
--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -605,6 +605,7 @@ compile_curl() {
     download_and_extract "${url}"
     [ -z "${CURL_VERSION}" ] && CURL_VERSION=$(echo "${SOURCE_DIR}" | cut -d'-' -f 2)
 
+    if [ ! -f src/.checksrc ]; then echo "enable STDERR" > src/.checksrc; fi
     curl_config;
     make -j "$(nproc)" LDFLAGS="-L${PREFIX}/lib -L${PREFIX}/lib64 -static -all-static" CFLAGS="-O3";
     tar_curl;

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -587,7 +587,7 @@ curl_config() {
             --enable-threaded-resolver --enable-optimize --enable-pthreads \
             --enable-warnings --enable-werror \
             --enable-curldebug --enable-dict --enable-netrc \
-            --enable-crypto-auth --enable-tls-srp --enable-dnsshuffle \
+            --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
             --enable-get-easy-options --enable-progress-meter \
             --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
             --with-ca-path=/etc/ssl/certs \


### PR DESCRIPTION
- fix the tarball with the .checksrc file
- no enable-crypto-auth parameter, change it to enable-bearer-auth