### PR TITLE
Fix missing command separator in macos script

### DIFF
--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -56,9 +56,9 @@ install_packages() {
 _clang_path() {
     # find the path of clang
     clang_path=$(which /usr/local/opt/llvm/bin/clang || which /opt/homebrew/opt/llvm/bin/clang \
-        which /Library/Developer/CommandLineTools/usr/bin/clang || which clang || true)
+        || which /Library/Developer/CommandLineTools/usr/bin/clang || which clang || true)
     clang_pp_path=$(which /usr/local/opt/llvm/bin/clang++ || which /opt/homebrew/opt/llvm/bin/clang++ \
-        which /Library/Developer/CommandLineTools/usr/bin/clang++ || which clang++ || true)
+        || which /Library/Developer/CommandLineTools/usr/bin/clang++ || which clang++ || true)
 
     if [ -z "${clang_path}" ] || [ -z "${clang_pp_path}" ]; then
         echo "clang not found"


### PR DESCRIPTION
This fix solves the issue with clang detection (#49):
```
Makefile:2491: *** missing separator.  Stop.
```

Now it works with `ARCHS="arm64"`.