### PR TITLE
Specify architecture for cmake on macOS

### DIFF
--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -443,7 +443,8 @@ compile_brotli() {
     cd out/
 
     PKG_CONFIG="pkg-config --static" LDFLAGS="${LDFLAGS}" \
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DBUILD_SHARED_LIBS=OFF ..;
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_OSX_ARCHITECTURES:STRING="${ARCH}" ..;
     PKG_CONFIG="pkg-config --static" LDFLAGS="${LDFLAGS}" \
         cmake --build . --config Release --target install;
 


### PR DESCRIPTION
The remaining problem in macOS script is incorrect static library architecture for `libbrotli*`: https://github.com/stunnel/static-curl/issues/49#issuecomment-1911674833

To specify that in `cmake` on macOS we need to define `CMAKE_OSX_ARCHITECTURES` parameter.