### PR TITLE
Allow customizing RELEASE_DIR on macos

### DIFF
--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -16,7 +16,7 @@ init_env() {
     local number
     export DIR="${DIR:-${HOME}/build}"
     export PREFIX="${DIR}/curl"
-    export RELEASE_DIR=${DIR};
+    export RELEASE_DIR=${RELEASE_DIR:-${HOME}};
     number=$(sysctl -n hw.ncpu 2>/dev/null)
     export CPU_CORES=${number:-1}
 
@@ -29,7 +29,7 @@ init_env() {
 
     echo "Source directory: ${DIR}"
     echo "Prefix directory: ${PREFIX}"
-    echo "Release directory: ${HOME}"
+    echo "Release directory: ${RELEASE_DIR}"
     echo "Architecture: ${ARCH}"
     echo "cURL version: ${CURL_VERSION}"
     echo "TLS Library: ${TLS_LIB}"
@@ -551,7 +551,7 @@ compile_curl() {
 }
 
 install_curl() {
-    mkdir -p "${HOME}/release/"
+    mkdir -p "${RELEASE_DIR}/release/"
 
     ls -l src/curl
     file src/curl
@@ -559,10 +559,10 @@ install_curl() {
     sha256sum src/curl
     src/curl -V || true
 
-    cp -f src/curl "${HOME}/release/curl-macos-${arch}"
+    cp -f src/curl "${RELEASE_DIR}/release/curl-macos-${arch}"
 
-    if [ ! -f "${HOME}/version.txt" ]; then
-        echo "${CURL_VERSION}" > "${HOME}/version.txt"
+    if [ ! -f "${RELEASE_DIR}/version.txt" ]; then
+        echo "${CURL_VERSION}" > "${RELEASE_DIR}/version.txt"
     fi
 }
 


### PR DESCRIPTION
This change brings an ability to customize `release` directory location in macOS builds script.