### PR TITLE
feat: Add --enable-ssls-export / 'SSLS-EXPORT' feature new to 8.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Simply execute it to compile the most recent version.
 
 `curl -V`
 - Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
-- Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Largefile libz NTLM PSL SSL threadsafe TLS-SRP TrackMemory UnixSockets zstd
+- Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Largefile libz NTLM PSL SSL SSLS-EXPORT threadsafe TLS-SRP TrackMemory UnixSockets zstd
 
 ## Usage
 

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -784,7 +784,8 @@ curl_config() {
             --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
             --with-ca-path=/etc/ssl/certs \
             --with-ca-fallback --enable-ares \
-            --disable-ldap --disable-ldaps "${ENABLE_DEBUG}";
+            --disable-ldap --disable-ldaps --enable-ssls-export \
+            "${ENABLE_DEBUG}";
 }
 
 compile_curl() {

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -537,7 +537,8 @@ curl_config() {
             --with-ca-path=/etc/ssl/certs \
             --with-ca-fallback --enable-ares \
             --disable-ldap --disable-ldaps --disable-rtsp \
-            --disable-rtmp --disable-rtmps "${ENABLE_DEBUG}" \
+            --disable-rtmp --disable-rtmps --enable-ssls-export \
+            "${ENABLE_DEBUG}" \
             CFLAGS="-I${PREFIX}/include" \
             CPPFLAGS="-I${PREFIX}/include";
 }

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -642,7 +642,8 @@ curl_config() {
             --enable-get-easy-options --enable-progress-meter \
             --without-ca-bundle --without-ca-path \
             --without-ca-fallback --enable-ares \
-            --disable-ldap --disable-ldaps "${ENABLE_DEBUG}";
+            --disable-ldap --disable-ldaps --enable-ssls-export \
+            "${ENABLE_DEBUG}";
 }
 
 compile_curl() {


### PR DESCRIPTION
See https://github.com/curl/curl/pull/15924

Current build omits this opt-in experimental feature and outputs an error if attempted to be used:
```
curl: option --ssl-sessions: the installed libcurl version does not support this
```
