### PR TITLE
feat: support ECH version release tag and filename

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -366,8 +366,9 @@ jobs:
       - name: Compress and Create Release Note
         env:
           TLS_LIB: ${{ vars.TLS_LIB }}
+          CURL_VERSION: ${{ env.VERSION }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         run: |
-          TLS_LIB=${TLS_LIB}
           bash release.sh
 
       - name: List compressed files
@@ -383,12 +384,13 @@ jobs:
           body_path: release/release.md
           tag_name: ${{ env.RELEASE_TAG }}
           name: Release ${{ env.RELEASE_TAG }}
+          make_latest: ${{ env.RELEASE_TAG == env.VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: curl-release-${{ env.VERSION }}
+          name: curl-release-${{ env.RELEASE_TAG }}
           path: release
           retention-days: 90
           if-no-files-found: error

--- a/release.sh
+++ b/release.sh
@@ -2,10 +2,11 @@
 
 init_env() {
     current_dir=$(dirname "$(realpath "$0")")
-    export RELEASE_DIR=${current_dir};
+    export RELEASE_DIR="${current_dir}";
     cd "${RELEASE_DIR}" || exit
-    CURL_VERSION=$(head -n 1 release/version.txt)
-    export CURL_VERSION=${CURL_VERSION}
+    CURL_VERSION="${CURL_VERSION:-$(head -n 1 release/version.txt)}"
+    export CURL_VERSION="${CURL_VERSION}"
+    export RELEASE_TAG="${RELEASE_TAG:-${CURL_VERSION}}"
 }
 
 create_release_note() {
@@ -61,9 +62,9 @@ tar_curl() {
         if [ -f "${trurl_filename}" ]; then
             mv "${trurl_filename}" trurl;
             sha256sum trurl >> SHA256SUMS;
-            XZ_OPT=-9 tar -Jcf "${file}-${CURL_VERSION}.tar.xz" curl trurl SHA256SUMS && rm -f curl trurl;
+            XZ_OPT=-9 tar -Jcf "${file}-${RELEASE_TAG}.tar.xz" curl trurl SHA256SUMS && rm -f curl trurl;
         else
-            XZ_OPT=-9 tar -Jcf "${file}-${CURL_VERSION}.tar.xz" curl SHA256SUMS && rm -f curl;
+            XZ_OPT=-9 tar -Jcf "${file}-${RELEASE_TAG}.tar.xz" curl SHA256SUMS && rm -f curl;
         fi
     done
 
@@ -76,9 +77,9 @@ tar_curl() {
         if [ -f "${trurl_filename}" ]; then
             mv "${trurl_filename}" trurl.exe;
             sha256sum trurl.exe >> SHA256SUMS;
-            XZ_OPT=-9 tar -Jcf "${filename}-${CURL_VERSION}.tar.xz" curl.exe trurl.exe curl-ca-bundle.crt SHA256SUMS && rm -f curl.exe trurl.exe;
+            XZ_OPT=-9 tar -Jcf "${filename}-${RELEASE_TAG}.tar.xz" curl.exe trurl.exe curl-ca-bundle.crt SHA256SUMS && rm -f curl.exe trurl.exe;
         else
-            XZ_OPT=-9 tar -Jcf "${filename}-${CURL_VERSION}.tar.xz" curl.exe curl-ca-bundle.crt SHA256SUMS && rm -f curl.exe;
+            XZ_OPT=-9 tar -Jcf "${filename}-${RELEASE_TAG}.tar.xz" curl.exe curl-ca-bundle.crt SHA256SUMS && rm -f curl.exe;
         fi
     done
     rm -f curl-ca-bundle.crt SHA256SUMS;


### PR DESCRIPTION
- Add `RELEASE_TAG` variable support for version suffix (-ech)
- Change archive filenames to use `RELEASE_TAG` instead of `CURL_VERSION`
- Add `make_latest` parameter to mark as latest only when `RELEASE_TAG` equals `VERSION`