### PR TITLE
fix: use brotli v1.1.0 for loongarch64 to avoid build failure

### DIFF
--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -692,6 +692,11 @@ compile_brotli() {
 
     url_from_github google/brotli "${BROTLI_VERSION}"
     url="${URL}"
+    # for loongarch64, if version is 1.2.0, replace it with 1.1.0
+    # there is a bug in 1.2.0 for loongarch64, see https://github.com/google/brotli/commit/e230f474b87134e8c6c85b630084c612057f253e
+    if [ "${ARCH}" = "loongarch64" ]; then
+        url=$(echo "${url}" | sed 's/v1.2.0/v1.1.0/g');
+    fi
     download_and_extract "${url}"
 
     mkdir -p out


### PR DESCRIPTION
Workaround for brotli v1.2.0 bug on loongarch64 architecture. See: https://github.com/google/brotli/commit/e230f474b87134e8c6c85b630084c612057f253e