### PR TITLE
feat: support OpenSSL 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This script utilizes `clang`(glibc) and [qbt-musl-cross-make](https://github.com
 
 #### Linux
 
-- To compile locally, install Docker, clone this Git repository, navigate to the repository directory, and then execute the following command:  
+- Install Docker, clone this Git repository, navigate to the repository directory, and then execute the following command:  
 `sh curl-static-cross.sh`  
 The script will create a container and compile the host architecture cURL only.  
 
@@ -134,7 +134,7 @@ ARCHES="x86_64 arm64" \
 
 #### Windows
 
-- To compile locally, install Docker, clone this Git repository, navigate to the repository directory, and then execute the following command:  
+- Install Docker, clone this Git repository, navigate to the repository directory, and then execute the following command:  
   `ARCHES="x86_64 i686 aarch64 armv7" sh curl-static-win.sh`  
   script will create a Linux container and cross-compile cURL via [LLVM MinGW toolchain](https://github.com/mstorsjo/llvm-mingw).
 
@@ -169,7 +169,7 @@ For all `VERSION` variables, leaving them blank will automatically fetch the lat
 - `LIBC`: The libc. `glibc`(default) or `musl`, only affects Linux.
 - `QBT_MUSL_CROSS_MAKE_VERSION`: The version of qbt-musl-cross-make, only affects `musl`. Check the releases on [qbt-musl-cross-make/releases](https://github.com/userdocs/qbt-musl-cross-make/releases)
 - `CURL_VERSION`: The version of cURL. If set to `dev`, will fetch the latest source code of branch `master` from GitHub.
-- `ENABLE_ECH`: Enable ECH support in cURL. The default value is `false`, set to `true` to enable this feature. Currently released OpenSSL versions do not support ECH. You must use OpenSSL's `feature/ech` branch; see the `OPENSSL_VERSION` and `OPENSSL_BRANCH` settings below. Current releases `static-curl` do not enable this feature, you have to compile by yourself if you need it.
+- `ENABLE_ECH`: Enable ECH support in cURL. The default value is `false`, set to `true` to enable this feature.
 - `OPENSSL_VERSION`: The version of OpenSSL. If set to `dev`, will fetch the branch `OPENSSL_BRANCH` from GitHub.
 - `OPENSSL_BRANCH`: The branch that fetch from GitHub, this variable will be ignored if `OPENSSL_VERSION` is not set to `dev`.
 - `NGTCP2_VERSION`: The version of ngtcp2.
@@ -191,4 +191,8 @@ The compiled files will be saved in the current `release` directory.
 
 ### ECH Support
 
-see [Environment Variables](#environment-variables)
+We are currently providing two build variants for this release: one with ECH support and one without.
+
+- Standard Version: Built with the latest stable OpenSSL release (3.6.x) for optimal reliability.
+- ECH-enabled Version: Built with OpenSSL 4.0.0 alpha. Please note that this is an experimental build and may contain bugs or stability issues.
+- Future Roadmap: Upon the official release of OpenSSL 4.0, we will transition to providing only the ECH-enabled version.

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -573,7 +573,7 @@ compile_ares() {
 
 compile_tls() {
     echo "Compiling ${TLS_LIB}, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local url no_hw_padlock no_pie_tests_asm cflags
+    local url ssl3 no_hw_padlock no_pie_tests_asm cflags
     change_dir;
 
     if [ "${OPENSSL_VERSION}" = "dev" ] && [ -n "${OPENSSL_BRANCH}" ]; then
@@ -594,13 +594,22 @@ compile_tls() {
     fi
 
     # issues/83 VIA padlock
-    if [ "${ARCH}" = "x86_64" ] || [ "${ARCH}" = "i686" ]; then
-        no_hw_padlock="no-hw-padlock"
+    # ssl3 is deprecated in 4.x
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+        ssl3=""
+        no_hw_padlock=""
+    else
+        ssl3="enable-ssl3 enable-ssl3-method"
+        case "$ARCH" in
+            x86_64|i686) no_hw_padlock="no-hw-padlock" ;;
+            *) no_hw_padlock="" ;;
+        esac
     fi
 
     # no-asm no-pie no-tests for i686 with musl libc
     # gcc 15 and musl have more strict security checks, so need to disable the i686 asm, uses pure C code,
-    # It affects approximately 5% of performance.
+    # it affects approximately 5% of performance.
     if [ "${ARCH}" = "i686" ] && [ "${LIBC}" = "musl" ]; then
         no_pie_tests_asm="no-pie no-tests no-asm"
     fi
@@ -623,7 +632,7 @@ compile_tls() {
         ${EC_NISTP_64_GCC_128} \
         enable-ktls \
         enable-tls1_3 \
-        enable-ssl3 enable-ssl3-method \
+        ${ssl3} \
         enable-des enable-rc4 \
         enable-weak-ssl-ciphers \
         --static -static;

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -596,12 +596,12 @@ compile_tls() {
     # issues/83 VIA padlock
     # ssl3 is deprecated in 4.x
     major_ver="${OPENSSL_VERSION%%.*}"
-    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
         ssl3=""
         no_hw_padlock=""
     else
         ssl3="enable-ssl3 enable-ssl3-method"
-        case "$ARCH" in
+        case "${ARCH}" in
             x86_64|i686) no_hw_padlock="no-hw-padlock" ;;
             *) no_hw_padlock="" ;;
         esac
@@ -812,6 +812,19 @@ curl_config() {
         true|yes|y|Y)
             with_ech="--enable-ech" ;;
     esac
+
+    # Resolve OpenSSL 4.x compatibility issues where API returns 'const' pointers.
+    # These flags prevent "discarded-qualifiers" warnings from being treated as errors 
+    # when -Werror is enabled.
+    # - GCC: -Wno-error=discarded-qualifiers
+    # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
+        export CFLAGS="${CFLAGS}
+            -Wno-error=incompatible-pointer-types-discards-qualifiers
+            -Wno-error=discarded-qualifiers
+            -Wno-error=cast-qual"
+    fi
 
     if [ ! -f configure ]; then
         autoreconf -fi;

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -820,10 +820,14 @@ curl_config() {
     # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
     major_ver="${OPENSSL_VERSION%%.*}"
     if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
-        export CFLAGS="${CFLAGS}
-            -Wno-error=incompatible-pointer-types-discards-qualifiers
-            -Wno-error=discarded-qualifiers
-            -Wno-error=cast-qual"
+        case "${CC}" in
+            clang*)
+                export CFLAGS="${CFLAGS} -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=cast-qual"
+                ;;
+            *)
+                export CFLAGS="${CFLAGS} -Wno-error=discarded-qualifiers -Wno-error=cast-qual"
+                ;;
+        esac
     fi
 
     if [ ! -f configure ]; then
@@ -850,7 +854,7 @@ curl_config() {
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \
         --enable-headers-api --enable-versioned-symbols \
         --enable-threaded-resolver --enable-optimize --enable-pthreads \
-        --enable-warnings --enable-werror \
+        --enable-warnings \
         --enable-curldebug --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -342,7 +342,7 @@ compile_ares() {
 
 compile_tls() {
     echo "Compiling ${TLS_LIB}, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local url
+    local url ssl3
     change_dir;
 
     if [ "${OPENSSL_VERSION}" = "dev" ] && [ -n "${OPENSSL_BRANCH}" ]; then
@@ -362,6 +362,14 @@ compile_tls() {
         download_and_extract "${url}"
     fi
 
+    # ssl3 is deprecated in 4.x
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+        ssl3=""
+    else
+        ssl3="enable-ssl3 enable-ssl3-method"
+    fi
+
     ./Configure \
         ${OPENSSL_ARCH} \
         -fPIC \
@@ -371,7 +379,7 @@ compile_tls() {
         enable-ktls \
         enable-ec_nistp_64_gcc_128 \
         enable-tls1_3 \
-        enable-ssl3 enable-ssl3-method \
+        ${ssl3} \
         enable-des enable-rc4 \
         enable-weak-ssl-ciphers;
 

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -533,8 +533,8 @@ curl_config() {
     # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
     major_ver="${OPENSSL_VERSION%%.*}"
     if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
-        export CFLAGS="${CFLAGS}
-            -Wno-error=incompatible-pointer-types-discards-qualifiers
+        export CFLAGS="${CFLAGS} \
+            -Wno-error=incompatible-pointer-types-discards-qualifiers \
             -Wno-error=cast-qual"
     fi
 
@@ -561,7 +561,7 @@ curl_config() {
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \
         --enable-headers-api --enable-versioned-symbols \
         --enable-threaded-resolver --enable-optimize --enable-pthreads \
-        --enable-warnings --enable-werror \
+        --enable-warnings \
         --enable-curldebug --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -364,7 +364,7 @@ compile_tls() {
 
     # ssl3 is deprecated in 4.x
     major_ver="${OPENSSL_VERSION%%.*}"
-    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
         ssl3=""
     else
         ssl3="enable-ssl3 enable-ssl3-method"
@@ -525,6 +525,18 @@ curl_config() {
         true|yes|y|Y)
             with_ech="--enable-ech" ;;
     esac
+
+    # Resolve OpenSSL 4.x compatibility issues where API returns 'const' pointers.
+    # These flags prevent "discarded-qualifiers" warnings from being treated as errors 
+    # when -Werror is enabled.
+    # - GCC: -Wno-error=discarded-qualifiers
+    # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
+        export CFLAGS="${CFLAGS}
+            -Wno-error=incompatible-pointer-types-discards-qualifiers
+            -Wno-error=cast-qual"
+    fi
 
     if [ ! -f configure ]; then
         autoreconf -fi;

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -399,7 +399,7 @@ compile_ares() {
 
 compile_tls() {
     echo "Compiling ${TLS_LIB}, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local url openssl_arch ec_nistp_64_gcc_128
+    local url openssl_arch ec_nistp_64_gcc_128 ssl3
     change_dir;
 
     if [ "${OPENSSL_VERSION}" = "dev" ] && [ -n "${OPENSSL_BRANCH}" ]; then
@@ -417,6 +417,14 @@ compile_tls() {
         url_from_github openssl/openssl "${OPENSSL_VERSION}"
         url="${URL}"
         download_and_extract "${url}"
+    fi
+
+    # ssl3 is deprecated in 4.x
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+        ssl3=""
+    else
+        ssl3="enable-ssl3 enable-ssl3-method"
     fi
 
     case "${ARCH}" in
@@ -463,7 +471,7 @@ compile_tls() {
         enable-ktls \
         ${ec_nistp_64_gcc_128} \
         enable-tls1_3 \
-        enable-ssl3 enable-ssl3-method \
+        ${ssl3} \
         enable-des enable-rc4 \
         enable-weak-ssl-ciphers \
         --static -static;

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -682,7 +682,7 @@ curl_config() {
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \
         --enable-headers-api --enable-versioned-symbols \
         --enable-threaded-resolver --enable-optimize \
-        --enable-warnings --enable-werror \
+        --enable-warnings \
         --enable-curldebug --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -421,7 +421,7 @@ compile_tls() {
 
     # ssl3 is deprecated in 4.x
     major_ver="${OPENSSL_VERSION%%.*}"
-    if [ "$OPENSSL_VERSION" = "dev" ] || { [ "$major_ver" -ge 4 ] 2>/dev/null; }; then
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
         ssl3=""
     else
         ssl3="enable-ssl3 enable-ssl3-method"


### PR DESCRIPTION
ssl3 is deprecated in OpenSSL 4.x

test pass:
https://github.com/stunnel/static-curl/actions/runs/22935847461