### PR TITLE
fix: enable ngtcp2

### DIFF
--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -682,11 +682,7 @@ compile_nghttp2() {
 }
 
 compile_ngtcp2() {
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        return
-    fi
     echo "Compiling ngtcp2, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-
     local url
     change_dir;
 
@@ -795,14 +791,7 @@ compile_trurl() {
 
 curl_config() {
     echo "Configuring curl, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local with_openssl_quic with_ech ac_cv_header_stdatomic_h
-
-    # --with-openssl-quic and --with-ngtcp2 are mutually exclusive
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        with_openssl_quic="--with-openssl-quic"
-    else
-        with_openssl_quic="--with-ngtcp2"
-    fi
+    local with_ech ac_cv_header_stdatomic_h
 
     if [ "${ARCH}" = "mips" ] && [ "${LIBC}" != "musl" ]; then
         ac_cv_header_stdatomic_h="ac_cv_header_stdatomic_h=no"
@@ -838,8 +827,8 @@ curl_config() {
         --host="${TARGET}" \
         --prefix="${PREFIX}" \
         --enable-static --disable-shared \
-        --with-openssl "${with_openssl_quic}" --with-brotli --with-zstd \
-        --with-nghttp2 --with-nghttp3 \
+        --with-openssl --with-brotli --with-zstd \
+        --with-nghttp2 --with-nghttp3 --with-ngtcp2 \
         --with-libidn2 --with-libssh2 \
         "${with_ech}" \
         "${ac_cv_header_stdatomic_h}" \
@@ -853,9 +842,9 @@ curl_config() {
         --enable-alt-svc --enable-websockets \
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \
         --enable-headers-api --enable-versioned-symbols \
-        --enable-threaded-resolver --enable-optimize --enable-pthreads \
+        --enable-threaded-resolver --enable-optimize \
         --enable-warnings \
-        --enable-curldebug --enable-dict --enable-netrc \
+        --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \
         --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # To compile locally, clone the Git repository, navigate to the repository directory,
 # and then execute the following command:
@@ -429,9 +429,6 @@ compile_nghttp2() {
 
 compile_ngtcp2() {
     echo "Compiling ngtcp2, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        return
-    fi
     local url
     change_dir;
 
@@ -445,8 +442,9 @@ compile_ngtcp2() {
 
     make -j "${CPU_CORES}";
     make install;
-    cp -a crypto/includes/ngtcp2/ngtcp2_crypto_quictls.h crypto/includes/ngtcp2/ngtcp2_crypto.h \
-        "${PREFIX}/include/ngtcp2/"
+
+    [[ ! -f "${PREFIX}/include/ngtcp2/ngtcp2_crypto.h" ]] && cp -a crypto/includes/ngtcp2/ngtcp2_crypto.h "${PREFIX}/include/ngtcp2/"
+    [[ ! -f "${PREFIX}/include/ngtcp2/ngtcp2_crypto_openssl.h" ]] && cp -a crypto/includes/ngtcp2/ngtcp2_crypto_quictls.h "${PREFIX}/include/ngtcp2/"
 
     _copy_license COPYING ngtcp2;
 }
@@ -512,14 +510,7 @@ compile_zstd() {
 
 curl_config() {
     echo "Configuring curl, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local with_openssl_quic with_ech
-
-    # --with-openssl-quic and --with-ngtcp2 are mutually exclusive
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        with_openssl_quic="--with-openssl-quic"
-    else
-        with_openssl_quic="--with-ngtcp2"
-    fi
+    local with_ech
 
     case "${ENABLE_ECH}" in
         true|yes|y|Y)
@@ -546,8 +537,8 @@ curl_config() {
         --host="${ARCH}-apple-darwin" \
         --prefix="${PREFIX}" \
         --disable-shared --enable-static \
-        --with-openssl "${with_openssl_quic}" --with-brotli --with-zstd \
-        --with-nghttp2 --with-nghttp3 \
+        --with-openssl --with-brotli --with-zstd \
+        --with-nghttp2 --with-nghttp3 --with-ngtcp2 \
         --with-libidn2 --with-libssh2 \
         "${with_ech}" \
         --enable-hsts --enable-mime --enable-cookies \
@@ -560,9 +551,9 @@ curl_config() {
         --enable-alt-svc --enable-websockets \
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \
         --enable-headers-api --enable-versioned-symbols \
-        --enable-threaded-resolver --enable-optimize --enable-pthreads \
+        --enable-threaded-resolver --enable-optimize \
         --enable-warnings \
-        --enable-curldebug --enable-dict --enable-netrc \
+        --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \
         --with-ca-bundle=/etc/ssl/cert.pem \

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -522,11 +522,7 @@ compile_nghttp2() {
 }
 
 compile_ngtcp2() {
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        return
-    fi
     echo "Compiling ngtcp2, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-
     local url
     change_dir;
 
@@ -636,14 +632,7 @@ compile_trurl() {
 
 curl_config() {
     echo "Configuring curl, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
-    local with_openssl_quic with_idn with_ech
-
-    # --with-openssl-quic and --with-ngtcp2 are mutually exclusive
-    if [ "${TLS_LIB}" = "openssl" ]; then
-        with_openssl_quic="--with-openssl-quic"
-    else
-        with_openssl_quic="--with-ngtcp2"
-    fi
+    local with_idn with_ech
 
     case "${ENABLE_ECH}" in
         true|yes|y|Y)
@@ -667,8 +656,8 @@ curl_config() {
         --host="${TARGET}" \
         --prefix="${PREFIX}" \
         --enable-static --disable-shared \
-        --with-openssl "${with_openssl_quic}" --with-brotli --with-zstd \
-        --with-nghttp2 --with-nghttp3 \
+        --with-openssl --with-brotli --with-zstd \
+        --with-nghttp2 --with-nghttp3 --with-ngtcp2 \
         "${with_idn}" --with-libssh2 \
         "${with_ech}" \
         --enable-hsts --enable-mime --enable-cookies \
@@ -683,7 +672,7 @@ curl_config() {
         --enable-headers-api --enable-versioned-symbols \
         --enable-threaded-resolver --enable-optimize \
         --enable-warnings \
-        --enable-curldebug --enable-dict --enable-netrc \
+        --enable-dict --enable-netrc \
         --enable-bearer-auth --enable-tls-srp --enable-dnsshuffle \
         --enable-get-easy-options --enable-progress-meter \
         --without-ca-bundle --without-ca-path \


### PR DESCRIPTION
curl 8.19.0 drops support for OpenSSL-QUIC
https://github.com/curl/curl/pull/20226