### PR TITLE
feat: default to OpenSSL 4.x with ECH enabled, drop ENABLE_ECH flag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,6 @@ on:
         required: false
         default: ''
         type: string
-      ENABLE_ECH:
-        description: 'Enable ECH Support'
-        required: false
-        default: false
-        type: boolean
       TLS_LIB:
         description: 'TLS Library (only openssl is supported for now)'
         required: false
@@ -27,7 +22,7 @@ on:
       OPENSSL_BRANCH:
         description: 'OpenSSL Branch'
         required: false
-        default: 'feature/ech'
+        default: ''
         type: string
       ARCHES_LINUX_GLIBC:
         description: "Linux glibc Architecture List (set 'none' to skip)"
@@ -67,7 +62,6 @@ jobs:
           # Set all build variables with fallback logic
           echo "ARCHES=${{ inputs.ARCHES_LINUX_GLIBC != '' && inputs.ARCHES_LINUX_GLIBC || vars.ARCHES_LINUX_GLIBC }}" >> $GITHUB_ENV
           echo "CURL_VERSION=${{ inputs.CURL_VERSION != '' && inputs.CURL_VERSION || vars.CURL_VERSION }}" >> $GITHUB_ENV
-          echo "ENABLE_ECH=${{ inputs.ENABLE_ECH }}" >> $GITHUB_ENV
           echo "TLS_LIB=${{ inputs.TLS_LIB != '' && inputs.TLS_LIB || vars.TLS_LIB }}" >> $GITHUB_ENV
           echo "OPENSSL_VERSION=${{ inputs.OPENSSL_VERSION != '' && inputs.OPENSSL_VERSION || vars.OPENSSL_VERSION }}" >> $GITHUB_ENV
           echo "OPENSSL_BRANCH=${{ inputs.OPENSSL_BRANCH != '' && inputs.OPENSSL_BRANCH || vars.OPENSSL_BRANCH }}" >> $GITHUB_ENV
@@ -130,7 +124,6 @@ jobs:
           # Set all build variables with fallback logic
           echo "ARCHES=${{ inputs.ARCHES_LINUX_MUSL != '' && inputs.ARCHES_LINUX_MUSL || vars.ARCHES_LINUX_MUSL }}" >> $GITHUB_ENV
           echo "CURL_VERSION=${{ inputs.CURL_VERSION != '' && inputs.CURL_VERSION || vars.CURL_VERSION }}" >> $GITHUB_ENV
-          echo "ENABLE_ECH=${{ inputs.ENABLE_ECH }}" >> $GITHUB_ENV
           echo "TLS_LIB=${{ inputs.TLS_LIB != '' && inputs.TLS_LIB || vars.TLS_LIB }}" >> $GITHUB_ENV
           echo "OPENSSL_VERSION=${{ inputs.OPENSSL_VERSION != '' && inputs.OPENSSL_VERSION || vars.OPENSSL_VERSION }}" >> $GITHUB_ENV
           echo "OPENSSL_BRANCH=${{ inputs.OPENSSL_BRANCH != '' && inputs.OPENSSL_BRANCH || vars.OPENSSL_BRANCH }}" >> $GITHUB_ENV
@@ -194,7 +187,6 @@ jobs:
           # Set all build variables with fallback logic
           echo "ARCHES=${{ inputs.ARCHES_WINDOWS != '' && inputs.ARCHES_WINDOWS || vars.ARCHES_WINDOWS }}" >> $GITHUB_ENV
           echo "CURL_VERSION=${{ inputs.CURL_VERSION != '' && inputs.CURL_VERSION || vars.CURL_VERSION }}" >> $GITHUB_ENV
-          echo "ENABLE_ECH=${{ inputs.ENABLE_ECH }}" >> $GITHUB_ENV
           echo "TLS_LIB=${{ inputs.TLS_LIB != '' && inputs.TLS_LIB || vars.TLS_LIB }}" >> $GITHUB_ENV
           echo "OPENSSL_VERSION=${{ inputs.OPENSSL_VERSION != '' && inputs.OPENSSL_VERSION || vars.OPENSSL_VERSION }}" >> $GITHUB_ENV
           echo "OPENSSL_BRANCH=${{ inputs.OPENSSL_BRANCH != '' && inputs.OPENSSL_BRANCH || vars.OPENSSL_BRANCH }}" >> $GITHUB_ENV
@@ -259,7 +251,6 @@ jobs:
           # Set all build variables with fallback logic
           echo "ARCHES=${{ inputs.ARCHES_MACOS != '' && inputs.ARCHES_MACOS || vars.ARCHES_MACOS }}" >> $GITHUB_ENV
           echo "CURL_VERSION=${{ inputs.CURL_VERSION != '' && inputs.CURL_VERSION || vars.CURL_VERSION }}" >> $GITHUB_ENV
-          echo "ENABLE_ECH=${{ inputs.ENABLE_ECH }}" >> $GITHUB_ENV
           echo "TLS_LIB=${{ inputs.TLS_LIB != '' && inputs.TLS_LIB || vars.TLS_LIB }}" >> $GITHUB_ENV
           echo "OPENSSL_VERSION=${{ inputs.OPENSSL_VERSION != '' && inputs.OPENSSL_VERSION || vars.OPENSSL_VERSION }}" >> $GITHUB_ENV
           echo "OPENSSL_BRANCH=${{ inputs.OPENSSL_BRANCH != '' && inputs.OPENSSL_BRANCH || vars.OPENSSL_BRANCH }}" >> $GITHUB_ENV
@@ -333,11 +324,7 @@ jobs:
 
       - name: Set RELEASE_TAG
         run: |
-          if [ "${{ inputs.ENABLE_ECH }}" = "true" ]; then
-            RELEASE_TAG="${{ env.VERSION }}-ech"
-          else
-            RELEASE_TAG="${{ env.VERSION }}"
-          fi
+          RELEASE_TAG="${{ env.VERSION }}"
           echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
           echo "Will release as: $RELEASE_TAG"
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Simply execute it to compile the most recent version.
 - [trurl](https://curl.se/trurl/)
 
 `curl -V`
-- Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
-- Features: alt-svc asyn-rr AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy HTTPSRR IDN IPv6 Largefile libz NTLM PSL SSL SSLS-EXPORT threadsafe TLS-SRP TrackMemory UnixSockets zstd
+- Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt mqtts pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
+- Features: alt-svc asyn-rr AsynchDNS brotli ECH HSTS HTTP2 HTTP3 HTTPS-proxy HTTPSRR IDN IPv6 Largefile libz NTLM PSL SSL SSLS-EXPORT threadsafe TLS-SRP UnixSockets zstd
 
 ## Usage
 
@@ -32,7 +32,8 @@ The binary is built with GitHub Actions.
 
 ### Release files
 
-Two versions of cURL will be released: one with ECH support (built with OpenSSL's branch feature/ecp) and one without, until OpenSSL's mainline supports ECH.
+Starting from cURL 8.20.0, all builds use OpenSSL 4.x with ECH support enabled by default.  
+For older releases (before 8.20.0), two versions were provided: one with ECH support and one without.
 
 - `curl-linux-ARCH-musl-VERSION`: binaries for Linux, linked with `musl`
 - `curl-linux-ARCH-glibc-VERSION`: binaries for Linux, linked with `glibc`, these binaries may have compatibility issues in certain system environments
@@ -169,7 +170,6 @@ For all `VERSION` variables, leaving them blank will automatically fetch the lat
 - `LIBC`: The libc. `glibc`(default) or `musl`, only affects Linux.
 - `QBT_MUSL_CROSS_MAKE_VERSION`: The version of qbt-musl-cross-make, only affects `musl`. Check the releases on [qbt-musl-cross-make/releases](https://github.com/userdocs/qbt-musl-cross-make/releases)
 - `CURL_VERSION`: The version of cURL. If set to `dev`, will fetch the latest source code of branch `master` from GitHub.
-- `ENABLE_ECH`: Enable ECH support in cURL. The default value is `false`, set to `true` to enable this feature.
 - `OPENSSL_VERSION`: The version of OpenSSL. If set to `dev`, will fetch the branch `OPENSSL_BRANCH` from GitHub.
 - `OPENSSL_BRANCH`: The branch that fetch from GitHub, this variable will be ignored if `OPENSSL_VERSION` is not set to `dev`.
 - `NGTCP2_VERSION`: The version of ngtcp2.
@@ -191,8 +191,7 @@ The compiled files will be saved in the current `release` directory.
 
 ### ECH Support
 
-We are currently providing two build variants for this release: one with ECH support and one without.
+Starting from cURL 8.20.0, ECH (Encrypted Client Hello) support is enabled by default using OpenSSL 4.x.
 
-- Standard Version: Built with the latest stable OpenSSL release (3.6.x) for optimal reliability.
-- ECH-enabled Version: Built with OpenSSL 4.0.0 alpha. Please note that this is an experimental build and may contain bugs or stability issues.
-- Future Roadmap: Upon the official release of OpenSSL 4.0, we will transition to providing only the ECH-enabled version.
+- **cURL >= 8.20.0**: Built with OpenSSL 4.x, ECH enabled by default.
+- **cURL < 8.20.0**: Two build variants were provided (with and without ECH support). OpenSSL 3.x is still supported for compatibility.

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -130,11 +130,11 @@ install_cross_compile() {
         # if the variable is set, get the specific version
         if [ -n "${QBT_MUSL_CROSS_MAKE_VERSION}" ]; then
             curl --retry 5 --retry-max-time 120 -s \
-                "https://api.github.com/repos/userdocs/qbt-musl-cross-make-test/releases/tags/${QBT_MUSL_CROSS_MAKE_VERSION}" \
+                "https://api.github.com/repos/userdocs/qbt-musl-cross-make/releases/tags/${QBT_MUSL_CROSS_MAKE_VERSION}" \
                 -o "github-qbt-musl-cross-make.json"
         else
             curl --retry 5 --retry-max-time 120 -s \
-                "https://api.github.com/repos/userdocs/qbt-musl-cross-make-test/releases" \
+                "https://api.github.com/repos/userdocs/qbt-musl-cross-make/releases" \
                 -o "github-qbt-musl-cross-make.json"
         fi
     fi

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -156,12 +156,6 @@ install_cross_compile() {
     download_and_extract "${url}"
 
     ln -s "${DIR}/${SOURCE_DIR}/${SOURCE_DIR}" "/${SOURCE_DIR}"
-    cd "/${SOURCE_DIR}/lib/"
-    if [ -f "libatomic.so" ]; then
-        mv libatomic.so libatomic.so.bak
-        ln -s libatomic.a libatomic.so
-    fi
-
     export CC="${DIR}/${SOURCE_DIR}/bin/${SOURCE_DIR}-cc" \
            CXX="${DIR}/${SOURCE_DIR}/bin/${SOURCE_DIR}-c++" \
            CFLAGS="-O3 -Wno-error=unknown-pragmas -Wno-error=sign-compare -Wno-error=cast-align -Wno-maybe-uninitialized -Wno-error=null-dereference" \

--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -2,7 +2,7 @@
 
 # To compile locally, install Docker, clone the Git repository, navigate to the repository directory,
 # and then execute the following command:
-# ARCHES="x86_64 aarch64" CURL_VERSION=8.16.0 TLS_LIB=openssl \
+# ARCHES="x86_64 aarch64" CURL_VERSION=8.19.0 TLS_LIB=openssl \
 #     ZLIB_VERSION= CONTAINER_IMAGE=debian:latest \
 #     sh curl-static-cross.sh
 # script will create a container and compile curl.
@@ -13,8 +13,7 @@
 #     -e RELEASE_DIR=/mnt \
 #     -e ARCHES="x86_64 aarch64 armv7 i686 riscv64 s390x" \
 #     -e ENABLE_DEBUG=0 \
-#     -e CURL_VERSION=8.16.0 \
-#     -e ENABLE_ECH="" \
+#     -e CURL_VERSION=8.19.0 \
 #     -e TLS_LIB=openssl \
 #     -e OPENSSL_VERSION="" \
 #     -e OPENSSL_BRANCH="" \
@@ -56,7 +55,6 @@ init_env() {
     echo "Host Architecture: ${ARCH_HOST}"
     echo "Architecture list: ${ARCHES}"
     echo "cURL version: ${CURL_VERSION}"
-    echo "enable ECH: ${ENABLE_ECH}"
     echo "TLS Library: ${TLS_LIB}"
     echo "OpenSSL version: ${OPENSSL_VERSION}"
     echo "OpenSSL branch: ${OPENSSL_BRANCH}"
@@ -797,11 +795,6 @@ curl_config() {
         ac_cv_header_stdatomic_h="ac_cv_header_stdatomic_h=no"
     fi
 
-    case "${ENABLE_ECH}" in
-        true|yes|y|Y)
-            with_ech="--enable-ech" ;;
-    esac
-
     # Resolve OpenSSL 4.x compatibility issues where API returns 'const' pointers.
     # These flags prevent "discarded-qualifiers" warnings from being treated as errors 
     # when -Werror is enabled.
@@ -809,6 +802,8 @@ curl_config() {
     # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
     major_ver="${OPENSSL_VERSION%%.*}"
     if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
+        echo "OpenSSL 4.x detected, enabling ECH support"
+        with_ech="--enable-ech"
         case "${CC}" in
             clang*)
                 export CFLAGS="${CFLAGS} -Wno-error=incompatible-pointer-types-discards-qualifiers -Wno-error=cast-qual"
@@ -966,7 +961,6 @@ _build_in_docker() {
         -e ARCHES="${ARCHES}" \
         -e ENABLE_DEBUG="${ENABLE_DEBUG}" \
         -e CURL_VERSION="${CURL_VERSION}" \
-        -e ENABLE_ECH="${ENABLE_ECH}" \
         -e TLS_LIB="${TLS_LIB}" \
         -e OPENSSL_VERSION="${OPENSSL_VERSION}" \
         -e OPENSSL_BRANCH="${OPENSSL_BRANCH}" \

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -2,7 +2,7 @@
 
 # To compile locally, clone the Git repository, navigate to the repository directory,
 # and then execute the following command:
-# ARCHES="x86_64 arm64" CURL_VERSION=8.16.0 TLS_LIB=openssl OPENSSL_VERSION=3.5.4 bash curl-static-mac.sh
+# ARCHES="x86_64 arm64" CURL_VERSION=8.19.0 TLS_LIB=openssl OPENSSL_VERSION=4.0.0 bash curl-static-mac.sh
 
 
 shopt -s expand_aliases;
@@ -29,7 +29,6 @@ init_env() {
     echo "Source directory: ${DIR}"
     echo "Release directory: ${RELEASE_DIR}"
     echo "cURL version: ${CURL_VERSION}"
-    echo "enable ECH: ${ENABLE_ECH}"
     echo "TLS Library: ${TLS_LIB}"
     echo "OpenSSL version: ${OPENSSL_VERSION}"
     echo "OpenSSL branch: ${OPENSSL_BRANCH}"
@@ -512,11 +511,6 @@ curl_config() {
     echo "Configuring curl, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
     local with_ech
 
-    case "${ENABLE_ECH}" in
-        true|yes|y|Y)
-            with_ech="--enable-ech" ;;
-    esac
-
     # Resolve OpenSSL 4.x compatibility issues where API returns 'const' pointers.
     # These flags prevent "discarded-qualifiers" warnings from being treated as errors 
     # when -Werror is enabled.
@@ -524,6 +518,8 @@ curl_config() {
     # - Clang: -Wno-error=incompatible-pointer-types-discards-qualifiers
     major_ver="${OPENSSL_VERSION%%.*}"
     if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
+        echo "OpenSSL 4.x detected, enabling ECH support"
+        with_ech="--enable-ech"
         export CFLAGS="${CFLAGS} \
             -Wno-error=incompatible-pointer-types-discards-qualifiers \
             -Wno-error=cast-qual"

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -2,7 +2,7 @@
 
 # To compile locally, install Docker, clone the Git repository, navigate to the repository directory,
 # and then execute the following command:
-# ARCHES="x86_64 i686" CURL_VERSION=8.16.0 TLS_LIB=openssl \
+# ARCHES="x86_64 i686" CURL_VERSION=8.19.0 TLS_LIB=openssl \
 #     ZLIB_VERSION= CONTAINER_IMAGE=mstorsjo/llvm-mingw:latest \
 #     sh curl-static-win.sh
 # script will create a container and compile curl.
@@ -13,8 +13,7 @@
 #     -e RELEASE_DIR=/mnt \
 #     -e ARCHES="x86_64 i686 aarch64 armv7" \
 #     -e ENABLE_DEBUG=0 \
-#     -e CURL_VERSION=8.16.0 \
-#     -e ENABLE_ECH="" \
+#     -e CURL_VERSION=8.19.0 \
 #     -e TLS_LIB=openssl \
 #     -e OPENSSL_VERSION="" \
 #     -e OPENSSL_BRANCH="" \
@@ -51,7 +50,6 @@ init_env() {
     echo "Host Architecture: ${ARCH_HOST}"
     echo "Architecture list: ${ARCHES}"
     echo "cURL version: ${CURL_VERSION}"
-    echo "enable ECH: ${ENABLE_ECH}"
     echo "TLS Library: ${TLS_LIB}"
     echo "OpenSSL version: ${OPENSSL_VERSION}"
     echo "OpenSSL branch: ${OPENSSL_BRANCH}"
@@ -634,15 +632,16 @@ curl_config() {
     echo "Configuring curl, Arch: ${ARCH}" | tee "${RELEASE_DIR}/running"
     local with_idn with_ech
 
-    case "${ENABLE_ECH}" in
-        true|yes|y|Y)
-            with_ech="--enable-ech" ;;
-    esac
-
     # it's possible to use libidn2 instead of winidn
     with_idn="--with-winidn"
     if [ -n "${LIBIDN2_VERSION}" ]; then
         with_idn="--with-libidn2"
+    fi
+
+    major_ver="${OPENSSL_VERSION%%.*}"
+    if [ "${OPENSSL_VERSION}" = "dev" ] || { [ "${major_ver}" -ge 4 ] 2>/dev/null; }; then
+        echo "OpenSSL 4.x detected, enabling ECH support"
+        with_ech="--enable-ech"
     fi
 
     if [ ! -f configure ]; then
@@ -797,7 +796,6 @@ _build_in_docker() {
         -e ARCHES="${ARCHES}" \
         -e ENABLE_DEBUG="${ENABLE_DEBUG}" \
         -e CURL_VERSION="${CURL_VERSION}" \
-        -e ENABLE_ECH="${ENABLE_ECH}" \
         -e TLS_LIB="${TLS_LIB}" \
         -e OPENSSL_VERSION="${OPENSSL_VERSION}" \
         -e OPENSSL_BRANCH="${OPENSSL_BRANCH}" \


### PR DESCRIPTION
ECH support is now automatically enabled when OpenSSL 4.x is detected, removing the need for the separate ENABLE_ECH toggle and dual-build workflow. OpenSSL 3.x remains supported for older releases.