### PR TITLE
fix: infer OpenSSL version from download URL

### DIFF
--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -418,6 +418,26 @@ url_from_github() {
     URL="${url}"
 }
 
+_set_openssl_version_from_url() {
+    local url candidate version
+    url=$1
+
+    [ -n "${OPENSSL_VERSION}" ] && return
+
+    candidate=$(printf "%s" "${url%%\?*}" \
+        | sed -E 's#/$##; s#^.*/##; s/\.(tar\.(xz|gz|bz2)|tgz|zip)$//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Vv]//' \
+        | tr '_' '.')
+    version=$(printf "%s" "${candidate}" | sed -n -E 's/^([0-9]+(\.[0-9]+)+[A-Za-z0-9._-]*).*/\1/p')
+
+    if [ -n "${version}" ]; then
+        OPENSSL_VERSION="${version}"
+        export OPENSSL_VERSION
+        echo "Resolved OpenSSL version: ${OPENSSL_VERSION}"
+    else
+        echo "WARNING. Failed to resolve OpenSSL version from URL: ${url}"
+    fi
+}
+
 download_and_extract() {
     echo "Downloading $1"
     local url
@@ -583,6 +603,7 @@ compile_tls() {
         url_from_github openssl/openssl "${OPENSSL_VERSION}"
         url="${URL}"
         download_and_extract "${url}"
+        _set_openssl_version_from_url "${url}"
     fi
 
     # issues/83 VIA padlock

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -211,6 +211,26 @@ url_from_github() {
     URL="${url}"
 }
 
+_set_openssl_version_from_url() {
+    local url candidate version
+    url=$1
+
+    [ -n "${OPENSSL_VERSION}" ] && return
+
+    candidate=$(printf "%s" "${url%%\?*}" \
+        | sed -E 's#/$##; s#^.*/##; s/\.(tar\.(xz|gz|bz2)|tgz|zip)$//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Vv]//' \
+        | tr '_' '.')
+    version=$(printf "%s" "${candidate}" | sed -n -E 's/^([0-9]+(\.[0-9]+)+[A-Za-z0-9._-]*).*/\1/p')
+
+    if [ -n "${version}" ]; then
+        OPENSSL_VERSION="${version}"
+        export OPENSSL_VERSION
+        echo "Resolved OpenSSL version: ${OPENSSL_VERSION}"
+    else
+        echo "WARNING. Failed to resolve OpenSSL version from URL: ${url}"
+    fi
+}
+
 download_and_extract() {
     echo "Downloading $1"
     local url
@@ -359,6 +379,7 @@ compile_tls() {
         url_from_github openssl/openssl "${OPENSSL_VERSION}"
         url="${URL}"
         download_and_extract "${url}"
+        _set_openssl_version_from_url "${url}"
     fi
 
     # ssl3 is deprecated in 4.x

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -249,6 +249,26 @@ url_from_github() {
     URL="${url}"
 }
 
+_set_openssl_version_from_url() {
+    local url candidate version
+    url=$1
+
+    [ -n "${OPENSSL_VERSION}" ] && return
+
+    candidate=$(printf "%s" "${url%%\?*}" \
+        | sed -E 's#/$##; s#^.*/##; s/\.(tar\.(xz|gz|bz2)|tgz|zip)$//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Oo]pen[Ss][Ss][Ll][-_]//; s/^[Vv]//' \
+        | tr '_' '.')
+    version=$(printf "%s" "${candidate}" | sed -n -E 's/^([0-9]+(\.[0-9]+)+[A-Za-z0-9._-]*).*/\1/p')
+
+    if [ -n "${version}" ]; then
+        OPENSSL_VERSION="${version}"
+        export OPENSSL_VERSION
+        echo "Resolved OpenSSL version: ${OPENSSL_VERSION}"
+    else
+        echo "WARNING. Failed to resolve OpenSSL version from URL: ${url}"
+    fi
+}
+
 download_and_extract() {
     echo "Downloading $1"
     local url
@@ -415,6 +435,7 @@ compile_tls() {
         url_from_github openssl/openssl "${OPENSSL_VERSION}"
         url="${URL}"
         download_and_extract "${url}"
+        _set_openssl_version_from_url "${url}"
     fi
 
     # ssl3 is deprecated in 4.x


### PR DESCRIPTION
When OPENSSL_VERSION is unset, resolve it from the downloaded OpenSSL archive URL so OpenSSL 4.x builds skip unsupported ssl3 options.

Keep explicitly provided OPENSSL_VERSION values unchanged.