### PR TITLE
fix: enable smb and NTLM

### DIFF
--- a/curl-static-cross.sh
+++ b/curl-static-cross.sh
@@ -1044,7 +1044,7 @@ curl_config() {
         --enable-proxy --enable-file --enable-http \
         --enable-ftp --enable-telnet --enable-tftp \
         --enable-pop3 --enable-imap --enable-smtp \
-        --enable-gopher --enable-mqtt \
+        --enable-gopher --enable-mqtt --enable-smb --enable-ntlm \
         --enable-doh --enable-dateparse --enable-verbose \
         --enable-alt-svc --enable-websockets \
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \

--- a/curl-static-mac.sh
+++ b/curl-static-mac.sh
@@ -760,7 +760,7 @@ curl_config() {
         --enable-proxy --enable-file --enable-http \
         --enable-ftp --enable-telnet --enable-tftp \
         --enable-pop3 --enable-imap --enable-smtp \
-        --enable-gopher --enable-mqtt \
+        --enable-gopher --enable-mqtt --enable-smb --enable-ntlm \
         --enable-doh --enable-dateparse --enable-verbose \
         --enable-alt-svc --enable-websockets \
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \

--- a/curl-static-win.sh
+++ b/curl-static-win.sh
@@ -882,7 +882,7 @@ curl_config() {
         --enable-proxy --enable-file --enable-http \
         --enable-ftp --enable-telnet --enable-tftp \
         --enable-pop3 --enable-imap --enable-smtp \
-        --enable-gopher --enable-mqtt \
+        --enable-gopher --enable-mqtt --enable-smb --enable-ntlm \
         --enable-doh --enable-dateparse --enable-verbose \
         --enable-alt-svc --enable-websockets \
         --enable-ipv6 --enable-unix-sockets --enable-socketpair \


### PR DESCRIPTION
fix: enable smb and NTLM, they are disabled by default in curl 8.20.0